### PR TITLE
[accent]Patch entire parser to exit with return code of 2 on uncovering ...

### DIFF
--- a/patches/entire.c.patch
+++ b/patches/entire.c.patch
@@ -1,5 +1,5 @@
 --- entire.c	2014-10-19 15:04:27.222220750 +0100
-+++ entire.c.modified	2014-10-19 12:43:07.129250249 +0100
++++ entire.c.modified	2014-11-14 13:43:19.683153354 +0000
 @@ -712,17 +712,17 @@
  
  	 printf("\n");
@@ -21,6 +21,17 @@
  	 printf("For ``%s'' at ", yyprintname(yygrammar[d-1]));
  	 print_coordinate(d-1);
  	 printf(",\n");
+@@ -737,8 +737,8 @@
+ 
+ 	 printf("\nEND OF GRAMMAR DEBUG INFORMATION\n\n");
+          yypos = posforerrormsg;
+-	 yyerror("source text uncovers unhandled grammar ambiguity");
+-	 exit(1);
++	 printf("source text uncovers unhandled grammar ambiguity");
++	 exit(2);
+ 
+ 	 selected_left = l;
+ 	 selected_sub = s;
 @@ -863,15 +863,15 @@
  
        printf("\n");
@@ -40,3 +51,36 @@
  
        if (test_for_cycle(s, sub[i])) {
  	 /* not possible */
+@@ -895,8 +895,8 @@
+       printf("\nEND OF GRAMMAR DEBUG INFORMATION\n\n");
+ 
+       yypos = posforerrormsg;
+-      yyerror("source text uncovers unhandled grammar ambiguity");
+-      exit(1);
++      printf("*** source text uncovers unhandled grammar ambiguity");
++      exit(2);
+ 
+    }
+    else if ((prio1 < 0) || (prio2 < 0)) {
+@@ -916,8 +916,8 @@
+                   yyprintname(yygrammar[d-1]));
+                printf("\nEND OF GRAMMAR DEBUG INFORMATION\n\n");
+                printf("-b-\n");
+-               yyerror("source text uncovers unhandled grammar ambiguity");
+-               exit(1);
++               printf("source text uncovers unhandled grammar ambiguity");
++               exit(2);
+             }
+          }
+ #endif
+@@ -941,8 +941,8 @@
+ 	       yyprintname(yygrammar[d-1]));
+ 	    printf("\nEND OF GRAMMAR DEBUG INFORMATION\n\n");
+             yypos = posforerrormsg;
+-	    yyerror("source text uncovers unhandled grammar ambiguity");
+-	    exit(1);
++	    printf("source text uncovers unhandled grammar ambiguity");
++	    exit(2);
+ 	 }
+       }
+ #endif


### PR DESCRIPTION
...ambiguity. This is so that we can distinguish between real errors and ambiguity
